### PR TITLE
Minimal update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "serde-example"
 version = "0.1.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "An example Serializer and Deserializer data format for Serde"
 repository = "https://github.com/serde-rs/example-format"

--- a/src/de.rs
+++ b/src/de.rs
@@ -13,7 +13,7 @@ use serde::de::{
     MapAccess, SeqAccess, VariantAccess, Visitor,
 };
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub struct Deserializer<'de> {
     // This string starts with the input data and characters are truncated off
@@ -26,6 +26,7 @@ impl<'de> Deserializer<'de> {
     // That way basic use cases are satisfied by something like
     // `serde_json::from_str(...)` while advanced use cases that require a
     // deserializer can make one with `serde_json::Deserializer::from_str(...)`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &'de str) -> Self {
         Deserializer { input }
     }
@@ -508,10 +509,7 @@ struct CommaSeparated<'a, 'de: 'a> {
 
 impl<'a, 'de> CommaSeparated<'a, 'de> {
     fn new(de: &'a mut Deserializer<'de>) -> Self {
-        CommaSeparated {
-            de,
-            first: true,
-        }
+        CommaSeparated { de, first: true }
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,7 +8,7 @@
 
 use serde::ser::{self, Serialize};
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub struct Serializer {
     // This string starts empty and JSON is appended as values are serialized.


### PR DESCRIPTION
Fixed paths to compile.
Also silenced stable clippy warning and applied stable rustfmt.